### PR TITLE
Add IP is_multicast , is_public functions

### DIFF
--- a/d8s_ip_addresses/ip_addresses.py
+++ b/d8s_ip_addresses/ip_addresses.py
@@ -52,6 +52,12 @@ def ip_is_multicast(ip):
     return ipaddress.ip_address(ip).is_multicast
 
 
+def ip_is_public(ip):
+    """Check if the IP address is public (i.e. not reserved and not multicast)."""
+    ip = ipaddress.ip_address(ip)
+    return not ip.is_multicast and not ip.is_private
+
+
 def is_ip_address(text):
     """Determine whether or not the given text is an ip address."""
     try:

--- a/d8s_ip_addresses/ip_addresses.py
+++ b/d8s_ip_addresses/ip_addresses.py
@@ -47,6 +47,11 @@ def ip_is_private(ip):
     return ipaddress.ip_address(ip).is_private
 
 
+def ip_is_multicast(ip):
+    """Check if the IP address is multicast."""
+    return ipaddress.ip_address(ip).is_multicast
+
+
 def is_ip_address(text):
     """Determine whether or not the given text is an ip address."""
     try:

--- a/tests/test_ip_addresses.py
+++ b/tests/test_ip_addresses.py
@@ -7,6 +7,7 @@ from d8s_ip_addresses import (
     ip_in_network_block,
     ip_is_private,
     ip_is_multicast,
+    ip_is_public,
     ip_is_reserved,
     ip_network_block_enumerate,
     ip_network_block_first_address,
@@ -82,6 +83,15 @@ def test_ip_is_multicast_docs_1():
     assert ip_is_multicast('224.0.0.1')
     assert not ip_is_multicast('8.8.8.8')
     assert not ip_is_multicast('127.0.0.1')
+
+
+def test_ip_is_public_docs_1():
+    assert ip_is_public('8.8.8.8')
+    assert ip_is_public('123.123.123.123')
+    assert not ip_is_public('224.0.0.1')
+    assert not ip_is_public('127.0.0.1')
+    assert not ip_is_public('192.168.0.4')
+    assert not ip_is_public('10.5.4.3')
 
 
 def test_ip_is_reserved_docs_1():

--- a/tests/test_ip_addresses.py
+++ b/tests/test_ip_addresses.py
@@ -6,6 +6,7 @@ from d8s_ip_addresses import (
     ip_current,
     ip_in_network_block,
     ip_is_private,
+    ip_is_multicast,
     ip_is_reserved,
     ip_network_block_enumerate,
     ip_network_block_first_address,
@@ -75,6 +76,12 @@ def test_ip_in_network_block_docs_1():
 def test_ip_is_private_docs_1():
     assert ip_is_private('10.0.0.1')
     assert not ip_is_private('8.8.8.8')
+
+
+def test_ip_is_multicast_docs_1():
+    assert ip_is_multicast('224.0.0.1')
+    assert not ip_is_multicast('8.8.8.8')
+    assert not ip_is_multicast('127.0.0.1')
 
 
 def test_ip_is_reserved_docs_1():


### PR DESCRIPTION
This PR adds a function to check if an IP is public.
i.e. not private and not multicast

equivalent to https://netaddr.readthedocs.io/en/latest/tutorial_01.html#public 